### PR TITLE
fixed handling of backslash character on US G910 Spark/Spectrum keybo…

### DIFF
--- a/src/Logi/GSeries/Keyboard/G910SparkUSQWERTY.java
+++ b/src/Logi/GSeries/Keyboard/G910SparkUSQWERTY.java
@@ -472,7 +472,7 @@ public class G910SparkUSQWERTY extends javax.swing.JInternalFrame {
                         case "076":
                             jPanelColour076.setBackground(jColorChooserFreeStyle.getColor());
                             jLayeredPane1.moveToBack(jPanelColour076);
-                            gKeyboard.setKey("intl_backslash", hexColour, true);
+                            gKeyboard.setKey("backslash", hexColour, true);
                             break;
                         case "077":
                             jPanelColour077.setBackground(jColorChooserFreeStyle.getColor());
@@ -6761,11 +6761,11 @@ public class G910SparkUSQWERTY extends javax.swing.JInternalFrame {
         convertedColours[116] = colours[28];
         convertedColours[117] = colours[48];
         convertedColours[118] = colours[49];
-        convertedColours[119] = "000000";
+        convertedColours[119] = colours[75];
         convertedColours[120] = colours[68];
         convertedColours[121] = colours[69];
         convertedColours[122] = colours[70];
-        convertedColours[123] = colours[75];
+        convertedColours[123] = "000000";
         convertedColours[124] = colours[83];
         convertedColours[125] = colours[84];
         convertedColours[126] = colours[85];
@@ -6890,7 +6890,7 @@ public class G910SparkUSQWERTY extends javax.swing.JInternalFrame {
         convertedColours[68] = colours[120];
         convertedColours[69] = colours[121];
         convertedColours[70] = colours[122];
-        convertedColours[75] = colours[123];
+        convertedColours[75] = colours[119];
         convertedColours[83] = colours[124];
         convertedColours[84] = colours[125];
         convertedColours[85] = colours[126];

--- a/src/Logi/GSeries/Keyboard/G910SpectrumUSQWERTY.java
+++ b/src/Logi/GSeries/Keyboard/G910SpectrumUSQWERTY.java
@@ -472,7 +472,7 @@ public class G910SpectrumUSQWERTY extends javax.swing.JInternalFrame {
                         case "076":
                             jPanelColour076.setBackground(jColorChooserFreeStyle.getColor());
                             jLayeredPane1.moveToBack(jPanelColour076);
-                            gKeyboard.setKey("intl_backslash", hexColour, true);
+                            gKeyboard.setKey("backslash", hexColour, true);
                             break;
                         case "077":
                             jPanelColour077.setBackground(jColorChooserFreeStyle.getColor());
@@ -6760,11 +6760,11 @@ public class G910SpectrumUSQWERTY extends javax.swing.JInternalFrame {
         convertedColours[116] = colours[28];
         convertedColours[117] = colours[48];
         convertedColours[118] = colours[49];
-        convertedColours[119] = "000000";
+        convertedColours[119] = colours[75]; // backslash
         convertedColours[120] = colours[68];
         convertedColours[121] = colours[69];
         convertedColours[122] = colours[70];
-        convertedColours[123] = colours[75];
+        convertedColours[123] = "000000";
         convertedColours[124] = colours[83];
         convertedColours[125] = colours[84];
         convertedColours[126] = colours[85];
@@ -6889,7 +6889,7 @@ public class G910SpectrumUSQWERTY extends javax.swing.JInternalFrame {
         convertedColours[68] = colours[120];
         convertedColours[69] = colours[121];
         convertedColours[70] = colours[122];
-        convertedColours[75] = colours[123];
+        convertedColours[75] = colours[119];
         convertedColours[83] = colours[124];
         convertedColours[84] = colours[125];
         convertedColours[85] = colours[126];

--- a/src/Logi/GSeries/Libraries/Keyboard.java
+++ b/src/Logi/GSeries/Libraries/Keyboard.java
@@ -129,7 +129,7 @@ public class Keyboard {
         tilde, minus, equal,
         open_bracket, close_bracket,
         semicolon, quote,
-        intl_backslash, comma, period, slash
+        backslash, comma, period, slash
     };
     
     public enum KeyG810USQWERTY { // 115 keys


### PR DESCRIPTION
Made some changes to the US G910 Spark/Spectrum key-color mappings to fix the issue with the backslash blinking out.  

- Changed the US keymap enums to be "backslash" instead of "intl_backslash".  This prevented the per-key interface from setting any color on the backslash key

- Changed the US color mappings; the old code had the keycode mapped to backslash forced to the color "000000".  So when you clicked set and exited the interface, it would map an empty color to the backslash key, which caused it to turn off

- Fixed the color mapping to load colors from the keyboard; this would cause a default color to be loaded on the backslash key when you opened the interface